### PR TITLE
118 backend para seguir e deixar de seguir

### DIFF
--- a/myapi/myapi/settings.py
+++ b/myapi/myapi/settings.py
@@ -62,7 +62,7 @@ AUTH_USER_MODEL = 'usuarios.User'
 
 AUTHENTICATION_BACKENDS = [
     'usuarios.authentication.EmailBackend', 
-    'django.contrib.auth.backends.ModelBackend'
+    # 'django.contrib.auth.backends.ModelBackend'
 ]
 
 MIDDLEWARE = [
@@ -79,7 +79,7 @@ MIDDLEWARE = [
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'usuarios.authentication.MyJWTAuthentication'
     ],
 }
 

--- a/myapi/usuarios/views.py
+++ b/myapi/usuarios/views.py
@@ -1,11 +1,14 @@
 from rest_framework import status
+
+from rest_framework.decorators import action
+
 from rest_framework.response import Response
 from rest_framework import viewsets
 
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.views import APIView
 
-from .models import User, Publication
+from .models import User, Publication, Connection
 from .serializers import UserSerializer, PublicationSerializer
 
 from .authentication import MyJWTAuthentication
@@ -16,9 +19,40 @@ class UserViewSet(viewsets.ModelViewSet):
     authentication_classes = [MyJWTAuthentication]
 
     def get_authenticators(self):
-        if self.request.method == 'POST':
+        if self.request.method == 'POST' and not self.request.path.endswith('/follow/') and not self.request.path.endswith('/unfollow/'):
             return []
         return super().get_authenticators()
+    
+    @action(detail=True, methods=['post'], url_path='follow', url_name='user-follow')
+    def follow(self, request, pk=None):
+        user_to_follow = self.get_object()
+        user = request.user
+
+        if user == user_to_follow:
+            return Response({'error': 'Você não pode seguir a si mesmo'}, status=status.HTTP_400_BAD_REQUEST)
+
+        connection_exists = Connection.objects.filter(usuario_alpha=user, usuario_beta=user_to_follow).exists()
+
+        if not connection_exists:
+            connection = Connection(usuario_alpha=user, usuario_beta=user_to_follow)
+            connection.save()
+        
+        return Response({'status': 'ok'})
+    
+    @action(detail=True, methods=['post'], url_path='unfollow', url_name='user-unfollow')
+    def unfollow(self, request, pk=None):
+        user_to_unfollow = self.get_object()
+        user = request.user
+                
+        if user == user_to_unfollow:
+            return Response({'error': 'Você não pode deixar de seguir a si mesmo'}, status=status.HTTP_400_BAD_REQUEST)
+
+        connection = Connection.objects.filter(usuario_alpha=user, usuario_beta=user_to_unfollow).first()
+        
+        if connection:
+            connection.delete()
+            
+        return Response({'status': 'ok'})
     
 class LogoutView(APIView):
     authentication_classes = [MyJWTAuthentication]

--- a/myapi/usuarios/views.py
+++ b/myapi/usuarios/views.py
@@ -33,9 +33,11 @@ class UserViewSet(viewsets.ModelViewSet):
 
         connection_exists = Connection.objects.filter(usuario_alpha=user, usuario_beta=user_to_follow).exists()
 
-        if not connection_exists:
-            connection = Connection(usuario_alpha=user, usuario_beta=user_to_follow)
-            connection.save()
+        if connection_exists:
+            return Response({'error': 'Você já segue este usuário'}, status=status.HTTP_400_BAD_REQUEST)
+    
+        connection = Connection(usuario_alpha=user, usuario_beta=user_to_follow)
+        connection.save()
         
         return Response({'status': 'ok'})
     
@@ -48,9 +50,11 @@ class UserViewSet(viewsets.ModelViewSet):
             return Response({'error': 'Você não pode deixar de seguir a si mesmo'}, status=status.HTTP_400_BAD_REQUEST)
 
         connection = Connection.objects.filter(usuario_alpha=user, usuario_beta=user_to_unfollow).first()
-        
-        if connection:
-            connection.delete()
+
+        if not connection:
+            return Response({'error': 'Você não segue este usuário'}, status=status.HTTP_400_BAD_REQUEST)
+
+        connection.delete()
             
         return Response({'status': 'ok'})
     


### PR DESCRIPTION
Este Pull Request resolve a issue #118 e inclui as seguintes mudanças:

## O que foi feito?
Foi implementada a funcionalidade de seguir e deixar de seguir usuários, com a adição de verificações para evitar comportamentos indesejados. Se um usuário tentar seguir outro usuário que já está sendo seguido ou tentar deixar de seguir um usuário que não está sendo seguido, uma mensagem de erro será exibida. Além disso, um usuário não pode seguir ou deixar de seguir a si mesmo.
![image](https://user-images.githubusercontent.com/53534886/236849690-6a6b25f2-f332-4dba-be0f-730408525978.png)
![image](https://user-images.githubusercontent.com/53534886/236849780-a9e98935-2f5e-413e-a11b-b71ff0c5f64c.png)
![image](https://user-images.githubusercontent.com/53534886/236849824-c04067b0-beae-4601-8a42-5007817eda0f.png)


Para garantir o correto funcionamento do backend, foram adicionados testes para verificar se as funcionalidades de seguir e deixar de seguir estão funcionando conforme o esperado.
![image](https://user-images.githubusercontent.com/53534886/236849269-90d78a5a-73c7-4b4e-ac8f-e4917f608554.png)
