### PR TITLE
feat: adiciona componente responsivo para upload das imagens na publi…

### DIFF
--- a/myfrontend/src/components/ImageUpload/index.js
+++ b/myfrontend/src/components/ImageUpload/index.js
@@ -1,0 +1,71 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { MdInsertPhoto, MdClose } from 'react-icons/md';
+import './styles.css';
+
+function ImageUpload(props) {
+    const { selectedFile, setSelectedFile } = props;
+    const [isDragOver, setIsDragOver] = useState(false);
+    const fileInput = useRef(null);
+
+    const handleFileInputChange = (e) => {
+        const file = e.target.files[0];
+        setSelectedFile(file);
+
+        e.target.value = null;
+    };
+
+    const handleClearImage = () => {
+        setSelectedFile(null);
+    };
+
+    const shouldRenderInput = !selectedFile || window.matchMedia("(min-width: 768px)").matches;
+
+    return (
+        <div className="image-upload-container">
+            <div
+                className={`image-upload-dropzone ${isDragOver ? 'drag-over' : ''}`}
+                onDragOver={(e) => {
+                    e.preventDefault();
+                    setIsDragOver(true);
+                }}
+                onDragLeave={() => setIsDragOver(false)}
+                onDrop={(e) => {
+                    e.preventDefault();
+                    setIsDragOver(false);
+                    const file = e.dataTransfer.files[0];
+                    setSelectedFile(file);
+                }}
+            >
+                {shouldRenderInput &&
+                    <input
+                        className="image-upload-input"
+                        type="file"
+                        accept="image/*"
+                        onChange={handleFileInputChange}
+                        ref={fileInput}
+                        title=""
+                    />
+                }
+                {selectedFile ? (
+                    <div className="preview-image-container">
+                        <img
+                            className="preview-image"
+                            src={URL.createObjectURL(selectedFile)}
+                            alt="Imagem selecionada"
+                        />
+                        <button className="clear-image-button" onClick={handleClearImage}>
+                            <MdClose size={16} />
+                        </button>
+                    </div>
+                ) : (
+                    <div className="image-upload-prompt">
+                        <MdInsertPhoto size={24} />
+                        <span>Arraste aqui</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default ImageUpload;

--- a/myfrontend/src/components/ImageUpload/styles.css
+++ b/myfrontend/src/components/ImageUpload/styles.css
@@ -1,0 +1,101 @@
+.image-upload-container .image-upload-dropzone {
+    width: 80%;
+    height: 70px;
+    max-height: 140px;
+    display: flex;
+    justify-content: space-between;
+    padding: 8px;
+    border-radius: 16px;
+    margin: auto;
+    align-items: center;
+    margin-top: 8px;
+    border: 2px dashed #ccc;
+  }
+  
+.image-upload-dropzone:hover,
+.image-upload-dropzone:focus,
+.image-upload-dropzone:active {
+    border-color: #007bff;
+}
+
+.image-upload-dropzone.drag-over {
+    border-color: #403f3f;
+  }
+
+.image-upload-container .preview-image-container .preview-image {
+    max-width: 100px;
+    width: auto;
+    height: 64px;
+    border-radius: 4px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+}
+
+.image-upload-container .image-upload-input {
+    color: transparent;
+}
+
+.image-upload-container .image-upload-input::-webkit-file-upload-button {
+    visibility: hidden;
+}
+
+.image-upload-container .image-upload-input::before {
+    content: 'Adicionar Imagem';
+    display: inline-block;
+    background-color: gray;
+    color: #fff;
+    padding: 0.5em 1em;
+    outline: none;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    border-radius: 0.25rem;
+    position: relative;
+    z-index: 1;
+}
+
+.image-upload-container .preview-image-container {
+    display: flex;
+    align-content: center;
+}
+
+.image-upload-container .preview-image-container .clear-image-button {
+    margin: 16px;
+    padding: 4px;
+    background-color: red;
+    height: max-content;
+}
+
+.image-upload-container .image-upload-prompt {
+    display: flex;
+    align-items: center;
+    margin: 16px;
+    gap: 8px;
+}
+
+@media (max-width: 1165px) {
+    .image-upload-container .image-upload-prompt span {
+      display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .image-upload-container .preview-image-container {
+        align-items: center;
+    }
+
+    .image-upload-container .preview-image-container .clear-image-button {
+        margin: 8px;
+        height: max-content;
+        max-width: 24px;
+    }
+
+    .image-upload-container .preview-image-container {
+        width: 100%;
+        justify-content: space-between;
+    }
+}

--- a/myfrontend/src/components/Publication/index.js
+++ b/myfrontend/src/components/Publication/index.js
@@ -5,6 +5,8 @@ import { AiFillPlusCircle } from 'react-icons/ai';
 import axios from "axios";
 import api from '../../api';
 
+import ImageUpload from "../ImageUpload";
+
 const REVIEWS = [
     { id: 1, value: '1 - Horrível' },
     { id: 2, value: '2 - Ruim' },
@@ -20,6 +22,7 @@ const Publication = () => {
     const [selectedMovie, setSelectedMovie] = useState({});
     const [postText, setPostText] = useState('');
     const [selectedReview, setSelectedReview] = useState('');
+    const [selectedFile, setSelectedFile] = useState(null);
 
     function handleReviewChange(event) {
         setSelectedReview(event.target.value);
@@ -119,6 +122,7 @@ const Publication = () => {
     }
 
     async function cancelPost() {
+        setSelectedFile(null);
         setSelectedMovie('')
         setSelectedReview('')
         setMovies([])
@@ -230,6 +234,7 @@ const Publication = () => {
                         </div>
                     </div>
                     <div id="align-post-review" className="align-post-review">
+                        <ImageUpload selectedFile={selectedFile} setSelectedFile={setSelectedFile} />
                         <div className="post-review-conf">
                             <p id="alert">Você só pode publicar se escrever uma crítica e selecionar um filme</p>
                         </div>

--- a/myfrontend/src/components/menu/styles.css
+++ b/myfrontend/src/components/menu/styles.css
@@ -45,6 +45,7 @@
         align-items: center;
         position: fixed;
         display: none;
+        z-index: 2;
     }
     
     .menu-contrast {
@@ -55,6 +56,7 @@
         width: 100%;
         padding-bottom: 100px;
         padding-left: 0%;
+        z-index: 2;
     }
 
     .inside-menu {


### PR DESCRIPTION
Este Pull Request resolve a issue #119 e inclui as seguintes mudanças:

## O que foi feito?
Foi adicionado um componente para upload de imagem no frontend. Para inserir uma imagem, pode clicar no componente ou arrastar uma imagem. 
![Imagem do WhatsApp de 2023-05-10 à(s) 11 54 34](https://github.com/lucasfirmo62/MovieReview/assets/53534886/6b995ffe-ea56-4ba2-a987-1748a9b56a15)
![Imagem do WhatsApp de 2023-05-09 à(s) 21 52 35](https://github.com/lucasfirmo62/MovieReview/assets/53534886/3353d8bc-9083-47d2-b9e3-7a2f1e71699d)

Quando clicado no botão cancelar do componente Publication, a seleção da imagem também é deixada e uma nova imagem precisa ser selecionada.

Pensando na responsividade, quando selecionado uma imagem em telas menores, o botão de adicionar imagem desaparece, voltando apenas quando a imagem é apagada da seleção.
![image](https://github.com/lucasfirmo62/MovieReview/assets/53534886/f595706b-aa71-40a3-a177-ebe14e37cb55)
![image](https://github.com/lucasfirmo62/MovieReview/assets/53534886/f6ca90f1-0b30-42e7-a7dc-332d115b7a56)

