### PR TITLE
fix: arruma tela de retorno das telas de following e followers

### DIFF
--- a/myfrontend/src/pages/followers/index.js
+++ b/myfrontend/src/pages/followers/index.js
@@ -8,7 +8,7 @@ import CardFollower from "../../components/CardFollower";
 
 import { MdArrowBack } from "react-icons/md";
 
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useLocation  } from "react-router-dom";
 
 const Followers = () => {
 
@@ -17,25 +17,31 @@ const Followers = () => {
   const [user, setUser] = useState([]);
   const [followers, setFollowers] = useState([]);
   const [following, setFollowing] = useState([]);
+  const location = useLocation();
 
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const handlePopstate = () => {
-      navigate.push("/profile");
-    };
-
-    window.addEventListener("popstate", handlePopstate);
-
-    return () => {
-      window.removeEventListener("popstate", handlePopstate);
-    };
-  }, [navigate]);
+  const backButtonRoute = location.state?.prevPath;
 
   const [windowSize, setWindowSize] = useState({
     width: window.innerWidth,
     height: window.innerHeight,
   });
+
+  // useEffect(() => {
+  //   const handleBrowserBackButton = (event) => {
+  //     if (event.type === 'popstate') {
+  //       console.log('Browser back button clicked');
+  //       history.push('/');
+  //     }
+  //   };
+
+  //   window.addEventListener('popstate', handleBrowserBackButton);
+
+  //   return () => {
+  //     window.removeEventListener('popstate', handleBrowserBackButton);
+  //   };
+  // }, [history]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -70,7 +76,7 @@ const Followers = () => {
       };
 
       try {
-        const userResponse = await api.get(`/usuarios/${idUser}/`, { headers });
+        const userResponse = await api.get(`/usuarios/${id}/`, { headers });
         const followersResponse = await api.get(`/followers/${id}/`, {
           headers,
         });
@@ -105,7 +111,7 @@ const Followers = () => {
           <div className="followers-info">
             <Link
               className="back-btn"
-              to={`/profile`}
+              to={backButtonRoute}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <MdArrowBack size={32} className="back-icon" />
@@ -117,6 +123,9 @@ const Followers = () => {
           <div className="tabs-profile">
             <Link
               to={`/followers/${id}`}
+              state={{
+                prevPath: backButtonRoute
+              }}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <p style={{backgroundColor: '#4b4949'}} className="tab-profile">Seguidores</p>
@@ -124,6 +133,9 @@ const Followers = () => {
 
             <Link
               to={`/following/${id}`}
+              state={{
+                prevPath: backButtonRoute
+              }}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <p className="tab-profile">Seguindo</p>

--- a/myfrontend/src/pages/following/index.js
+++ b/myfrontend/src/pages/following/index.js
@@ -7,7 +7,7 @@ import CardFollower from "../../components/CardFollower";
 
 import { MdArrowBack } from "react-icons/md";
 
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useLocation } from "react-router-dom";
 
 const Following = () => {
   const { id } = useParams();
@@ -15,19 +15,11 @@ const Following = () => {
   const [user, setUser] = useState([]);
   const [following, setFollowing] = useState([]);
 
+  const location = useLocation();
+
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const handlePopstate = () => {
-      navigate.push("/profile");
-    };
-
-    window.addEventListener("popstate", handlePopstate);
-
-    return () => {
-      window.removeEventListener("popstate", handlePopstate);
-    };
-  }, [navigate]);
+  const backButtonRoute = location.state?.prevPath;
 
   const [windowSize, setWindowSize] = useState({
     width: window.innerWidth,
@@ -66,11 +58,11 @@ const Following = () => {
         "Content-type": "application/json",
       };
 
-      await api.get(`/usuarios/${idUser}/`, { headers }).then((response) => {
+      await api.get(`/usuarios/${id}/`, { headers }).then((response) => {
         setUser(response.data);
       });
 
-      await api.get(`/usuarios/following/`, { headers }).then((response) => {
+      await api.get(`/following/${id}/`, { headers }).then((response) => {
         setFollowing(response.data);
       });
     }
@@ -94,7 +86,7 @@ const Following = () => {
           <div className="followers-info">
             <Link
               className="back-btn"
-              to={`/profile`}
+              to={backButtonRoute}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <MdArrowBack size={32} className="back-icon" />
@@ -106,6 +98,9 @@ const Following = () => {
           <div className="tabs-profile">
             <Link
               to={`/followers/${id}`}
+              state={{
+                prevPath: backButtonRoute
+              }}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <p className="tab-profile">Seguidores</p>
@@ -113,6 +108,9 @@ const Following = () => {
 
             <Link
               to={`/following/${id}`}
+              state={{
+                prevPath: backButtonRoute
+              }}
               style={{ textDecoration: "none", color: "#fff" }}
             >
               <p style={{backgroundColor: '#4b4949'}} className="tab-profile">Seguindo</p>

--- a/myfrontend/src/pages/profile/index.js
+++ b/myfrontend/src/pages/profile/index.js
@@ -117,13 +117,23 @@ const Profile = () => {
 
                     <div className={'tabs-profile'}>
                         <Link
-                            to={`/followers/${idUser}`}
+                            to={{
+                                pathname: `/followers/${idUser}`,
+                            }}
+                            state={{
+                                prevPath: '/profile'
+                            }}
                             style={{ textDecoration: "none", color: "#fff" }}
                         >
                             <p className={'tab-profile'}>{followers.length} Seguidores</p>
                         </Link>
                         <Link
-                            to={`/following/${idUser}`}
+                            to={{
+                                pathname: `/following/${idUser}`,
+                            }}
+                            state={{
+                                prevPath: '/profile'
+                            }}
                             style={{ textDecoration: "none", color: "#fff" }}
                         >
                             <p className={'tab-profile'}>{following.length} Seguindo</p>

--- a/myfrontend/src/pages/user/index.js
+++ b/myfrontend/src/pages/user/index.js
@@ -9,9 +9,11 @@ import FollowUnfollow from "../../components/Follow-Unfollow";
 
 import ViewPublication from "../../components/ViewPublication";
 
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 const User = () => {
+    const location = useLocation();
+
     const [windowSize, setWindowSize] = useState({
         width: window.innerWidth,
         height: window.innerHeight
@@ -212,13 +214,23 @@ const User = () => {
                     </div>
                     <div className={'tabs-profile'}>
                         <Link
-                            to={`/followers/${id}`}
+                            to={{
+                                pathname: `/followers/${id}`,
+                            }}
+                            state={{
+                                prevPath: location.pathname
+                            }}
                             style={{ textDecoration: "none", color: "#fff" }}
                         >
                             <p className={'tab-profile'}>{followers.length} Seguidores</p>
                         </Link>
                         <Link
-                            to={`/following/${id}`}
+                            to={{
+                                pathname: `/following/${id}`,
+                            }}
+                            state={{
+                                prevPath: location.pathname
+                            }}
                             style={{ textDecoration: "none", color: "#fff" }}
                         >
                             <p className={'tab-profile'}>{following.length} Seguindo</p>


### PR DESCRIPTION
Este Pull Request resolve a issue #184 e inclui as seguintes mudanças:

## O que foi feito?
Foi alterado a tela de retorno das telas de following e followers. Agora, ela verifica se o usuário veio da tela de profile ou da tela de user e faz o retorno para uma dessas telas. Anteriormente, o usuário era sempre redirecionado para a tela de profile.