### PR TITLE
fix: limita o numero de paginas de resultados

### DIFF
--- a/myfrontend/src/pages/search/index.js
+++ b/myfrontend/src/pages/search/index.js
@@ -190,7 +190,7 @@ const Search = () => {
                 
                 {users.length > 0 && (
                   <Pagination
-                    totalPages={totalPages}
+                    totalPages={totalPages > 5 ? 5 : totalPages}
                     currentPage={currentPage}
                     onPageChange={handlePageChange}
                   />
@@ -231,7 +231,7 @@ const Search = () => {
 
                 {movies.length > 0 && (
                   <Pagination
-                    totalPages={totalPages}
+                    totalPages={totalPages > 5 ? 5 : totalPages}
                     currentPage={currentPage}
                     onPageChange={handlePageChange}
                   />


### PR DESCRIPTION
Este Pull Request resolve a issue #182.

## O que foi feito?
Foi limitado a 5, a quantidade de páginas de resultados. Isso foi feito devido a pesquisas muito genéricas, tal como uma letra gerarem inúmeros resultados.
![image](https://github.com/lucasfirmo62/MovieReview/assets/53534886/e4c293b8-fc63-49da-9ea3-c56583c8476a)
