### PR TITLE
refactor: seta o token e o contentType globalmente no interceptador

### DIFF
--- a/myfrontend/src/api.js
+++ b/myfrontend/src/api.js
@@ -15,6 +15,25 @@ api.interceptors.request.use(
     access = access.substring(1, access.length - 1)
     refresh = refresh.substring(1, refresh.length - 1)
 
+    if (access) {
+      const headers = {
+        ...config.headers,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${access}`,
+      };
+
+      config.headers = headers;
+    }
+
+    if (config.url.endsWith('/publicacoes/')) {
+      const headers = {
+        ...config.headers,
+        'Content-Type': 'multipart/form-data',
+      };
+
+      config.headers = headers;
+    }
+
     const headers = {
       'Content-Type': 'application/json',
     };

--- a/myfrontend/src/components/CardFollower/index.js
+++ b/myfrontend/src/components/CardFollower/index.js
@@ -13,14 +13,8 @@ function CardFollower(props) {
   },[])
 
   async function unfollow(){
-    let token = localStorage.getItem('tokenUser')
-  
-    token = token.substring(1,token.length-1)
-    
-    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
     try {
-      const response = await api.post(`/usuarios/${props.id}/unfollow/`, null, {headers})
+      const response = await api.post(`/usuarios/${props.id}/unfollow/`, null)
     
       setIsFollowing(false)
     } catch (error) {
@@ -29,14 +23,8 @@ function CardFollower(props) {
   }
 
   async function follow(){
-    let token = localStorage.getItem('tokenUser')
-  
-    token = token.substring(1,token.length-1)  
-
-    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
     try {
-      const response = await api.post(`/usuarios/${props.id}/follow/`, null, {headers})
+      const response = await api.post(`/usuarios/${props.id}/follow/`, null)
 
       setIsFollowing(true)
     } catch (error) {

--- a/myfrontend/src/components/Follow-Unfollow/index.js
+++ b/myfrontend/src/components/Follow-Unfollow/index.js
@@ -8,14 +8,8 @@ const FollowUnfollow = (props) => {
     const [isFollowing, setIsFollowing] = useState(props.isFollower)
 
     async function unfollow() {
-        let token = localStorage.getItem('tokenUser')
-
-        token = token.substring(1, token.length - 1)
-
-        const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
         try {
-            const response = await api.post(`/usuarios/${props.id}/unfollow/`, null, { headers })
+            const response = await api.post(`/usuarios/${props.id}/unfollow/`, null)
 
             setIsFollowing(false)
         } catch (error) {
@@ -24,15 +18,8 @@ const FollowUnfollow = (props) => {
     }
 
     async function follow() {
-        console.log("user")
-        let token = localStorage.getItem('tokenUser')
-
-        token = token.substring(1, token.length - 1)
-
-        const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
         try {
-            const response = await api.post(`/usuarios/${props.id}/follow/`, null, { headers })
+            const response = await api.post(`/usuarios/${props.id}/follow/`, null)
 
             setIsFollowing(true)
         } catch (error) {

--- a/myfrontend/src/components/Publication/index.js
+++ b/myfrontend/src/components/Publication/index.js
@@ -125,10 +125,8 @@ const Publication = () => {
         formData.append('movie_id', data.movie_id);
         formData.append('movie_title', data.movie_title);
 
-        const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' };
-
         try {
-            const response = await api.post('/publicacoes/', formData, { headers });
+            const response = await api.post('/publicacoes/', formData);
             console.log(response.data);
 
             setMinLoadingTimePassed(false);

--- a/myfrontend/src/components/ViewPublication/index.js
+++ b/myfrontend/src/components/ViewPublication/index.js
@@ -13,22 +13,12 @@ const ViewPublication = ({ userID, idPost, idMovie, rating, critic, image, date,
     const navigate = useNavigate();
     const [user, setUser] = useState({})
 
-    let loginItem;
-    if (localStorage.getItem('tokenUser')) {
-        loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-    }
-
     useEffect(() => {
         const fetchData = async () => {
-            const headers = {
-                Authorization: `Bearer ${loginItem}`,
-                "Content-type": "application/json"
-            };
-
             const response = await axios.get(`https://api.themoviedb.org/3/movie/${idMovie}?api_key=${process.env.REACT_APP_TMDB_API_KEY}&language=pt-BR`);
             setMovie(response.data);
 
-            const response_user = await api.get(`usuarios/${userID}/`, { headers })
+            const response_user = await api.get(`usuarios/${userID}/`)
             setUser(response_user.data)
         };
 

--- a/myfrontend/src/components/menu/index.js
+++ b/myfrontend/src/components/menu/index.js
@@ -20,22 +20,15 @@ const Menu = () => {
     }
 
     const handleLogout = () => {
-        let access = localStorage.getItem("tokenUser")
         let refresh = localStorage.getItem("refreshTokenUser")
 
-        access = access.substring(1, access.length - 1);
         refresh = refresh.substring(1, refresh.length - 1);
 
-        const headers = {
-            'Authorization': 'Bearer ' + access,
-            'Content-Type': 'application/json'
-        }
-        
         const body = {
             "refresh": refresh
         }
 
-        api.post("/logout/", body, { headers })
+        api.post("/logout/", body)
             .then((res) => {
                 localStorage.setItem("tokenUser", "")
                 localStorage.setItem("refreshTokenUser", "")

--- a/myfrontend/src/pages/edit-profile/index.js
+++ b/myfrontend/src/pages/edit-profile/index.js
@@ -19,16 +19,12 @@ const EditProfile = () => {
 
     useEffect(() => {
         let id = localStorage.getItem('idUser')
-        let token = localStorage.getItem('tokenUser')
 
         id = id.substring(1, id.length - 1)
-        token = token.substring(1, token.length - 1)
-
-        const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
         const fetchUser = async () => {
             try {
-                const response = await api.get(`/usuarios/${id}/`, { headers });
+                const response = await api.get(`/usuarios/${id}/`);
 
                 setUser({
                     full_name: response.data.full_name,
@@ -45,19 +41,15 @@ const EditProfile = () => {
 
     const handleSaveChanges = () => {
         let id = localStorage.getItem('idUser')
-        let token = localStorage.getItem('tokenUser')
 
         id = id.substring(1, id.length - 1)
-        token = token.substring(1, token.length - 1)
-
-        const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
         if (!user.full_name || !user.nickname || !user.bio_text) {
             alert("Por favor, preencha todos os campos");
             return;
         }
 
-        api.patch(`/usuarios/${id}/`, user, { headers })
+        api.patch(`/usuarios/${id}/`, user)
             .then(response => {
                 console.log('Dados do usuário atualizados com sucesso:', response.data);
                 navigate('/profile')

--- a/myfrontend/src/pages/favoritos/index.js
+++ b/myfrontend/src/pages/favoritos/index.js
@@ -13,15 +13,7 @@ const Favoritos = () => {
 
   useEffect(() => {
     async function getMovies() {
-      let id = localStorage.getItem('idUser')
-      let token = localStorage.getItem('tokenUser')
-
-      id = id.substring(1, id.length - 1)
-      token = token.substring(1, token.length - 1)
-
-      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
-      const response = await api.get('/favoritos/', { headers })
+      const response = await api.get('/favoritos/')
 
       await setFavoriteList(response.data)
     }
@@ -29,16 +21,8 @@ const Favoritos = () => {
   }, [])
 
   async function clickDesfavoritar(index) {
-    let id = localStorage.getItem('idUser');
-    let token = localStorage.getItem('tokenUser');
-
-    id = id.substring(1, id.length - 1);
-    token = token.substring(1, token.length - 1);
-
-    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
     try {
-      await api.delete(`/favoritos/${index}/`, { headers });
+      await api.delete(`/favoritos/${index}/`);
 
       setFavoriteList(prevList => {
         const updatedList = [...prevList];

--- a/myfrontend/src/pages/followers/index.js
+++ b/myfrontend/src/pages/followers/index.js
@@ -42,35 +42,17 @@ const Followers = () => {
       window.removeEventListener("resize", handleResize);
     };
   }, []);
-
-  var loginItem;
-
-  if (localStorage.getItem("tokenUser")) {
-    loginItem = localStorage
-      .getItem("tokenUser")
-      .substring(1, localStorage.getItem("tokenUser").length - 1);
-  }
-
+  
   var idUser = localStorage.getItem("idUser");
 
   useEffect(() => {
     async function userUtility() {
-
-      const headers = {
-        Authorization: `Bearer ${loginItem}`,
-        "Content-type": "application/json",
-      };
-
       try {
-        const userResponse = await api.get(`/usuarios/${id}/`, { headers });
+        const userResponse = await api.get(`/usuarios/${id}/`);
         
-        const followersResponse = await api.get(`/followers/${id}/`, {
-          headers,
-        });
+        const followersResponse = await api.get(`/followers/${id}/`);
 
-        const followingResponse = await api.get(`/usuarios/following/`, {
-          headers,
-        });
+        const followingResponse = await api.get(`/usuarios/following/`);
 
         setUser(userResponse.data);
         setFollowers(followersResponse.data);

--- a/myfrontend/src/pages/following/index.js
+++ b/myfrontend/src/pages/following/index.js
@@ -42,41 +42,24 @@ const Following = () => {
     };
   }, []);
 
-  var loginItem;
-
-  if (localStorage.getItem("tokenUser")) {
-    loginItem = localStorage
-      .getItem("tokenUser")
-      .substring(1, localStorage.getItem("tokenUser").length - 1);
-  }
-
   var idUser = localStorage.getItem("idUser");
 
   useEffect(() => {
     async function userUtility() {
-      const headers = {
-        Authorization: `Bearer ${loginItem}`,
-        "Content-type": "application/json",
-      };
-
-      await api.get(`/usuarios/${id}/`, { headers }).then((response) => {
+      await api.get(`/usuarios/${id}/`).then((response) => {
         setUser(response.data);
       });
 
-      const UserfollowingResponse = await api.get(`/following/${id}/`, {
-        headers,
-      });
+      const UserfollowingResponse = await api.get(`/following/${id}/`);
 
-      const followingResponse = await api.get(`/usuarios/following/`, {
-        headers,
-      });
+      const followingResponse = await api.get(`/usuarios/following/`);
 
       SetCurrentUserFollowing(followingResponse.data)
       setFollowing(UserfollowingResponse.data)
     }
 
     userUtility();
-  }, [idUser, loginItem]);
+  }, [idUser]);
 
   return (
     <>

--- a/myfrontend/src/pages/home/index.js
+++ b/myfrontend/src/pages/home/index.js
@@ -37,23 +37,12 @@ const Home = () => {
         };
     }, [])
 
-    let loginItem;
-
-    if (localStorage.getItem('tokenUser')) {
-        loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-    }
-
     const fetchFeed = async () => {
         if (page === 1) {
             isFirstPageRef.current = true;
         }
 
-        const headers = {
-            Authorization: `Bearer ${loginItem}`,
-            "Content-type": "application/json"
-        };
-
-        const response = await api.get(`feed/?page=${page}`, { headers });
+        const response = await api.get(`feed/?page=${page}`);
         setPublications(prevPublications => [...prevPublications, ...response.data.results]);
     };
 

--- a/myfrontend/src/pages/movie/index.js
+++ b/myfrontend/src/pages/movie/index.js
@@ -83,26 +83,15 @@ const Movie = () => {
         document.getElementById("trailer").src = "https://www.youtube.com/embed/undefined";
     }
 
-    let loginItem;
-    if (localStorage.getItem('tokenUser')) {
-        loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-    }
-
     async function toggleFavoritar() {
         const data = {
-            "user_id": loginItem,
             "movie_id": id,
             "poster_img": `https://image.tmdb.org/t/p/w500/${movie.poster_path}`,
             "movie_title": movie.title
         }
 
-        const headers = {
-            Authorization: `Bearer ${loginItem}`,
-            "Content-type": "application/json"
-        };
-
         try {
-            await api.post('/favoritos/', data, { headers })
+            await api.post('/favoritos/', data)
 
             setIsMovieFavorite(true)
         } catch(error) {
@@ -111,13 +100,8 @@ const Movie = () => {
     }
 
     async function toggleDesfavoritar() {
-        const headers = {
-            Authorization: `Bearer ${loginItem}`,
-            "Content-type": "application/json"
-        };
-
         try {
-            await api.delete(`/favoritos/${id}/`, { headers })
+            await api.delete(`/favoritos/${id}/`)
 
             setIsMovieFavorite(false)
         } catch(error) {
@@ -126,14 +110,9 @@ const Movie = () => {
     }
 
     useEffect(() => {
-        async function get_data() {
-            const headers = {
-                Authorization: `Bearer ${loginItem}`,
-                "Content-type": "application/json"
-            };
-            
+        async function get_data() {            
             try {
-                const response = await api.get(`/favoritos/${id}/is_movie_favorite/`, { headers })
+                const response = await api.get(`/favoritos/${id}/is_movie_favorite/`)
                 setIsMovieFavorite(response.data.is_favorite)
             } catch (error) {
                 console.log(error)

--- a/myfrontend/src/pages/profile/index.js
+++ b/myfrontend/src/pages/profile/index.js
@@ -24,7 +24,6 @@ const Profile = () => {
     const [following, setFollowing] = useState([]);
     const isFirstPageRef = useRef(false);
 
-    var loginItem;
     const [windowSize, setWindowSize] = useState({
         width: window.innerWidth,
         height: window.innerHeight
@@ -47,36 +46,23 @@ const Profile = () => {
 
     const navigate = useNavigate();
 
-    if (localStorage.getItem('tokenUser')) {
-        loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-    }
-
     var idUser = localStorage.getItem('idUser');
 
     useEffect(() => {
         async function userUtility() {
-            const headers = {
-                Authorization: `Bearer ${loginItem}`,
-                "Content-type": "application/json"
-            };
-
-            await api.get(`/usuarios/${idUser}/`, { headers })
+            await api.get(`/usuarios/${idUser}/`)
                 .then(response => { setUser(response.data) })
             
-            const followersResponse = await api.get(`/usuarios/followers/`, {
-                    headers,
-            });
+            const followersResponse = await api.get(`/usuarios/followers/`);
 
-            const followingResponse = await api.get(`/usuarios/following/`, {
-                headers,
-            });
+            const followingResponse = await api.get(`/usuarios/following/`);
           
             setFollowers(followersResponse.data);
             setFollowing(followingResponse.data);
         }
 
         userUtility()
-    }, [idUser, loginItem])
+    }, [idUser])
 
     async function goEditProfile() {
         navigate("/edit-profile")
@@ -88,12 +74,7 @@ const Profile = () => {
             isFirstPageRef.current = true;
         }
 
-        const headers = {
-            Authorization: `Bearer ${loginItem}`,
-            "Content-type": "application/json"
-        };
-
-        const response = await api.get(`pubusuario/${idUser}/?page=${page}`, { headers });
+        const response = await api.get(`pubusuario/${idUser}/?page=${page}`);
         setPublications(prevPublications => [...prevPublications, ...response.data.results]);
     };
 

--- a/myfrontend/src/pages/search/index.js
+++ b/myfrontend/src/pages/search/index.js
@@ -64,20 +64,10 @@ const Search = () => {
     };
   }, []);
 
-  let loginItem;
-  if (localStorage.getItem('tokenUser')) {
-    loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-  }
-
   useEffect(() => {
     if (query === null) {
       const fetchData = async () => {
-        const headers = {
-          Authorization: `Bearer ${loginItem}`,
-          "Content-type": "application/json"
-        }
-        
-        const response = await api.get(`/usuarios/search/?nickname=${user}&page=${currentPage}`, { headers });
+        const response = await api.get(`/usuarios/search/?nickname=${user}&page=${currentPage}`);
   
         setUsers(response.data.results.results);
   

--- a/myfrontend/src/pages/sign-up/index.js
+++ b/myfrontend/src/pages/sign-up/index.js
@@ -165,11 +165,7 @@ const SignUp = () => {
 
         try {
 
-            await api.post('/usuarios/', data, {
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
+            await api.post('/usuarios/', data);
 
             navigate('/login');
 

--- a/myfrontend/src/pages/user/index.js
+++ b/myfrontend/src/pages/user/index.js
@@ -50,31 +50,15 @@ const User = () => {
 
     const navigate = useNavigate();
 
-    var loginItem;
-
-    if (localStorage.getItem('tokenUser')) {
-        loginItem = localStorage.getItem('tokenUser').substring(1, localStorage.getItem('tokenUser').length - 1);
-    }
-
     var idMyUser = localStorage.getItem('idUser');
 
     useEffect(() => {
         async function userUtility() {
-            await api.get(`/usuarios/${id}/`, {
-                headers: {
-                    Authorization: `Bearer ${loginItem}`,
-                    "Content-type": "application/json"
-                },
-            })
+            await api.get(`/usuarios/${id}/`)
                 .then(response => { setUser(response.data) })
 
             try {
-                const responseFollowing = await api.get(`/following/${id}/`, {
-                    headers: {
-                        Authorization: `Bearer ${loginItem}`,
-                        "Content-type": "application/json"
-                    },
-                })
+                const responseFollowing = await api.get(`/following/${id}/`)
 
                 setFollowing(responseFollowing.data)
             } catch (error) {
@@ -82,12 +66,7 @@ const User = () => {
             }
 
             try {
-                const responseFollowers = await api.get(`/followers/${id}/`, {
-                    headers: {
-                        Authorization: `Bearer ${loginItem}`,
-                        "Content-type": "application/json"
-                    },
-                })
+                const responseFollowers = await api.get(`/followers/${id}/`)
 
                 setFollowers(responseFollowers.data)
 
@@ -96,12 +75,7 @@ const User = () => {
             }
 
             try {
-                const responseFollowing = await api.get(`/following/${idMyUser}/`, {
-                    headers: {
-                        Authorization: `Bearer ${loginItem}`,
-                        "Content-type": "application/json"
-                    },
-                })
+                const responseFollowing = await api.get(`/following/${idMyUser}/`)
 
                 setMyFollowing(responseFollowing.data)
             } catch (error) {
@@ -109,12 +83,7 @@ const User = () => {
             }
 
             try {
-                const responseFollowers = await api.get(`/followers/${idMyUser}/`, {
-                    headers: {
-                        Authorization: `Bearer ${loginItem}`,
-                        "Content-type": "application/json"
-                    },
-                })
+                const responseFollowers = await api.get(`/followers/${idMyUser}/`)
 
                 setMyFollowers(responseFollowers.data)
 
@@ -127,7 +96,7 @@ const User = () => {
         
         userUtility()
 
-    }, [idMyUser, loginItem])
+    }, [idMyUser])
     
     async function goEditProfile() {
         navigate("/edit-profile")
@@ -138,12 +107,7 @@ const User = () => {
             isFirstPageRef.current = true;
         }
 
-        const headers = {
-            Authorization: `Bearer ${loginItem}`,
-            "Content-type": "application/json"
-        };
-
-        const response = await api.get(`/pubusuario/${id}/?page=${page}`, { headers });
+        const response = await api.get(`/pubusuario/${id}/?page=${page}`);
         console.log("pao doce", response.data.results)
         setPublications(prevPublications => [...prevPublications, ...response.data.results]);
     };


### PR DESCRIPTION
Anteriormente havia a necessidade de resgatar o token e setar a header para toda a requisição.

Para alterar esse comportamento. Foi setado o token e o Content-Type no interceptador das requisições, tal como no exemplo apresentado na imagem abaixo. 
![image](https://github.com/lucasfirmo62/MovieReview/assets/53534886/7966fcc6-b44c-4379-9064-4d8821134f82)

Além disso, também foi retirado todas as ocorrências em que o usuário resgatava o token no localStorage e o passava na header.
Após as alterações apresentadas, as requisições estão sendo realizadas como apresentado na imagem abaixo.
![image](https://github.com/lucasfirmo62/MovieReview/assets/53534886/1e8625b6-9481-47b4-b4f5-810e9859b4db)
